### PR TITLE
added Dockerfile to provide portable build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM        ubuntu:saucy
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+RUN apt-get -y install build-essential gcc-4.8 g++-4.8 libboost1.53-all-dev git cmake unzip clang libz-dev libcurl4-openssl-dev imagemagick
+ADD . /usr/src/pnxt/
+WORKDIR /usr/src/pnxt/src/
+RUN ./m_unix
+CMD ls -la ../build/release/src/ 


### PR DESCRIPTION
I've noticed that people were reporting having difficulties building pNXTd. Now with this Dockerfile, anyone running a platform that has a Docker client available, or a virtual machine or cloud VPS that can run Docker, will be able to build pNXTd from source.

If you're familiar with Docker, this should be self-explanatory, but if not:

`docker build -t pnxt .`, when run in the root of the git repository, will build a docker image based on ubuntu saucy that runs the ./m_unix script to build the pNXTd source. 

`docker run -it pnxt /bin/bash` should attach you to a running version of the container in a bash shell, essentially your own VM. Ports can be exposed and directories shared between the host and the docker container if needed. Right now I've just gotten this built and haven't tested much beyond seeing that the binaries are built successfully.

The directory that the source is located in within the container is /usr/src/pnxt.

Let me know if you have any questions, I might push this to the docker index if there's enough interest.
